### PR TITLE
Add LoRa E220 base and balloon projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Stratum Projects
+
+This repository contains two PlatformIO projects that communicate using LoRa E220 modules.
+
+- `estacao_base` — code that runs on the ground station ESP32.
+- `balao` — code that runs on the balloon ESP32.
+
+Both projects share a common library under `lib_shared` that wraps the LoRa E220 driver.
+
+Each project has its own `platformio.ini` so they can be built independently using PlatformIO.
+

--- a/balao/platformio.ini
+++ b/balao/platformio.ini
@@ -1,0 +1,6 @@
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+framework = arduino
+lib_extra_dirs = ../lib_shared
+lib_deps = renzo-mischianti/LoRa_E220

--- a/balao/src/main.cpp
+++ b/balao/src/main.cpp
@@ -1,0 +1,17 @@
+#include <Arduino.h>
+#include "lora_e220.h"
+
+void setup() {
+  Serial.begin(9600);
+  delay(500);
+  setupE220();
+  sendMessage("Hello from balloon!");
+}
+
+void loop() {
+  if (Serial.available()) {
+    String input = Serial.readStringUntil('\n');
+    sendMessage(input);
+  }
+}
+

--- a/estacao_base/platformio.ini
+++ b/estacao_base/platformio.ini
@@ -1,0 +1,6 @@
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+framework = arduino
+lib_extra_dirs = ../lib_shared
+lib_deps = renzo-mischianti/LoRa_E220

--- a/estacao_base/src/main.cpp
+++ b/estacao_base/src/main.cpp
@@ -1,0 +1,18 @@
+#include <Arduino.h>
+#include "lora_e220.h"
+
+void setup() {
+  Serial.begin(9600);
+  delay(500);
+  setupE220();
+  Serial.println("Waiting for messages...");
+}
+
+void loop() {
+  String msg = checkForMessage();
+  if (msg.length() > 0) {
+    Serial.print("Mensagem recebida: ");
+    Serial.println(msg);
+  }
+}
+

--- a/lib_shared/lora_e220/lora_e220.cpp
+++ b/lib_shared/lora_e220/lora_e220.cpp
@@ -1,0 +1,36 @@
+#include "lora_e220.h"
+#include "Arduino.h"
+
+#define RXD2 15
+#define TXD2 14
+#define AUX  21
+#define M0   19
+#define M1   18
+
+LoRa_E220 e220ttl(&Serial2, AUX, M0, M1);
+
+void setupE220() {
+  Serial2.begin(9600, SERIAL_8N1, RXD2, TXD2);
+  e220ttl.begin();
+  e220ttl.setMode(MODE_0_NORMAL);
+}
+
+void sendMessage(const String& msg) {
+  ResponseStatus rs = e220ttl.sendBroadcastFixedMessage(23, msg);
+  Serial.println(rs.getResponseDescription());
+}
+
+String checkForMessage() {
+  if (e220ttl.available() > 1) {
+    ResponseContainer rc = e220ttl.receiveMessage();
+    if (rc.status.code != 1) {
+      Serial.println(rc.status.getResponseDescription());
+    } else {
+      Serial.println("Recebido:");
+      Serial.println(rc.data);
+      return rc.data;
+    }
+  }
+  return "";
+}
+

--- a/lib_shared/lora_e220/lora_e220.h
+++ b/lib_shared/lora_e220/lora_e220.h
@@ -1,0 +1,7 @@
+#pragma once
+#include "LoRa_E220.h"
+
+void setupE220();
+void sendMessage(const String& msg);
+String checkForMessage();
+


### PR DESCRIPTION
## Summary
- add two PlatformIO projects: `estacao_base` (ground station) and `balao` (balloon)
- share LoRa E220 wrapper library under `lib_shared`
- update README with project overview

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880f7e67e88832199a7cff5bbad03b0