### PR TITLE
Refactor shared LoRa E220 library

### DIFF
--- a/balao/src/main.cpp
+++ b/balao/src/main.cpp
@@ -44,7 +44,7 @@ static void delayWithHeartbeat(unsigned long ms) {
 void setup() {
   Serial.begin(9600);
   delay(500);
-  setupE220(LORA_RX, LORA_TX, LORA_AUX, LORA_M0, LORA_M1);
+  setupE220(Serial2, LORA_RX, LORA_TX, LORA_AUX, LORA_M0, LORA_M1);
   setupMagnetometer(PINO_DRDY);
   setupGPS(GPS_RX, GPS_TX);
   setupTemperatureSensors();

--- a/estacao_base/src/main.cpp
+++ b/estacao_base/src/main.cpp
@@ -10,7 +10,7 @@
 void setup() {
   Serial.begin(9600);
   delay(500);
-  setupE220(LORA_RX, LORA_TX, LORA_AUX, LORA_M0, LORA_M1);
+  setupE220(Serial2, LORA_RX, LORA_TX, LORA_AUX, LORA_M0, LORA_M1);
 
   Serial.println("Waiting for messages...");
 }

--- a/lib_shared/lora_e220/lora_e220.cpp
+++ b/lib_shared/lora_e220/lora_e220.cpp
@@ -1,12 +1,13 @@
 #include "lora_e220.h"
 #include "Arduino.h"
 
-static LoRa_E220* e220ttl = nullptr;
+LoRa_E220* e220ttl = nullptr;
 
-void setupE220(int rxPin, int txPin, int auxPin, int m0Pin, int m1Pin) {
-  Serial2.begin(9600, SERIAL_8N1, rxPin, txPin);
-  static LoRa_E220 lora(&Serial2, auxPin, m0Pin, m1Pin);
-  e220ttl = &lora;
+void setupE220(HardwareSerial& serial, int rxPin, int txPin, int auxPin,
+               int m0Pin, int m1Pin) {
+  serial.begin(9600, SERIAL_8N1, rxPin, txPin);
+  delete e220ttl;
+  e220ttl = new LoRa_E220(&serial, auxPin, m0Pin, m1Pin);
   e220ttl->begin();
   e220ttl->setMode(MODE_0_NORMAL);
 }

--- a/lib_shared/lora_e220/lora_e220.h
+++ b/lib_shared/lora_e220/lora_e220.h
@@ -1,7 +1,11 @@
 #pragma once
 #include "LoRa_E220.h"
+#include <HardwareSerial.h>
 
-void setupE220(int rxPin, int txPin, int auxPin, int m0Pin, int m1Pin);
+extern LoRa_E220* e220ttl;
+
+void setupE220(HardwareSerial& serial, int rxPin, int txPin,
+               int auxPin, int m0Pin, int m1Pin);
 
 void sendMessage(const String& msg);
 String checkForMessage();


### PR DESCRIPTION
## Summary
- refactor `lib_shared/lora_e220` to use a dynamically allocated instance
- allow `setupE220` to take a `HardwareSerial` reference
- update balloon and base station `main.cpp` to pass their serial ports

## Testing
- `pio run -d balao` *(fails: HTTPClientError due to blocked network)*


------
https://chatgpt.com/codex/tasks/task_e_68841c3c7ab08321bd0792201fcadfa5