### PR TITLE
Add minimal Serial2 examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,14 @@ pio run -d estacao_base
 ```
 
 
+
+## Simple Serial Examples
+
+Additional minimal projects show how to use the E22 modules without the `LoRa_E220` library. The directories `balao_simple` and `estacao_base_simple` configure Serial2 manually and control the mode pins directly.
+
+Build them with PlatformIO just like the main projects:
+
+```bash
+pio run -d balao_simple
+pio run -d estacao_base_simple
+```

--- a/balao_simple/platformio.ini
+++ b/balao_simple/platformio.ini
@@ -1,0 +1,5 @@
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+framework = arduino
+monitor_speed = 9600

--- a/balao_simple/src/main.cpp
+++ b/balao_simple/src/main.cpp
@@ -1,0 +1,33 @@
+#include <Arduino.h>
+
+#define LORA_RX 15
+#define LORA_TX 14
+#define LORA_AUX 21
+#define LORA_M0 19
+#define LORA_M1 18
+
+void setup() {
+  Serial.begin(9600);
+  Serial2.begin(9600, SERIAL_8N1, LORA_RX, LORA_TX);
+
+  pinMode(LORA_M0, OUTPUT);
+  pinMode(LORA_M1, OUTPUT);
+  pinMode(LORA_AUX, INPUT);
+
+  digitalWrite(LORA_M0, LOW);   // modo normal
+  digitalWrite(LORA_M1, LOW);
+
+  Serial.println("Balão pronto");
+}
+
+void loop() {
+  static float temp = 25.0;
+  char buffer[16];
+  sprintf(buffer, "TEMP:%.1f", temp);
+  Serial2.println(buffer);
+  Serial.print("Enviado: ");
+  Serial.println(buffer);
+
+  temp += 0.1; // simula mudança de temperatura
+  delay(5000);
+}

--- a/estacao_base_simple/platformio.ini
+++ b/estacao_base_simple/platformio.ini
@@ -1,0 +1,5 @@
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+framework = arduino
+monitor_speed = 9600

--- a/estacao_base_simple/src/main.cpp
+++ b/estacao_base_simple/src/main.cpp
@@ -1,0 +1,29 @@
+#include <Arduino.h>
+
+#define LORA_RX 15
+#define LORA_TX 14
+#define LORA_AUX 21
+#define LORA_M0 19
+#define LORA_M1 18
+
+void setup() {
+  Serial.begin(9600);
+  Serial2.begin(9600, SERIAL_8N1, LORA_RX, LORA_TX);
+
+  pinMode(LORA_M0, OUTPUT);
+  pinMode(LORA_M1, OUTPUT);
+  pinMode(LORA_AUX, INPUT);
+
+  digitalWrite(LORA_M0, LOW);   // modo normal
+  digitalWrite(LORA_M1, LOW);
+
+  Serial.println("Estação pronta. Aguardando...");
+}
+
+void loop() {
+  if (Serial2.available()) {
+    String msg = Serial2.readStringUntil('\n');
+    Serial.print("Recebido: ");
+    Serial.println(msg);
+  }
+}


### PR DESCRIPTION
## Summary
- add minimal transmitter and receiver projects that drive E22 modules using raw Serial2
- document simple projects in README

## Testing
- `pio run -d balao_simple` *(fails: HTTPClientError)*
- `pio run -d estacao_base_simple` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_688664b7d9108321994ff6652df76b03